### PR TITLE
Refactored Position of Regexp

### DIFF
--- a/logmon.go
+++ b/logmon.go
@@ -33,14 +33,17 @@ func readConf(path string) string {
 	return string(data)
 }
 
+var (
+	fileRe = regexp.MustCompile("^:(.*)")
+	targetRe = regexp.MustCompile("^\\((.*)\\)$")
+	ignoreRe = regexp.MustCompile("^\\[(.*)\\]$")
+	timeRe = regexp.MustCompile("^{(.*)}$")
+	commandRe = regexp.MustCompile("^[^#].*")
+)
+
 func parseConf(contentStr string) []Watching {
 	contents := strings.Split(contentStr, "\n")
 	ret := []Watching{}
-	fileRe := regexp.MustCompile("^:(.*)")
-	targetRe := regexp.MustCompile("^\\((.*)\\)$")
-	ignoreRe := regexp.MustCompile("^\\[(.*)\\]$")
-	timeRe := regexp.MustCompile("^{(.*)}$")
-	commandRe := regexp.MustCompile("^[^#].*")
 	var path string
 	var target, ignore *regexp.Regexp
 	var waitMillisecond int64


### PR DESCRIPTION
I made regexps as package valuables for decreasing memory allocation counts.

benchmark code (`logmon_test.go`, same folder w/ `logmon.go`)
```go
package main

import (
	"testing"
)

func Benchmark_parseConf(b *testing.B) {
	for i := 0; i < b.N; i++ {
			parseConf(`:/var/log/system.log\n(ERROR)\necho -e 'ERROR\n<%%%%>\n'`)
	}
}
```

before
```bash
$ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/MakoTano/logmon-go
Benchmark_parseConf-4   	   50000	     27605 ns/op	   55184 B/op	     198 allocs/op
PASS
ok  	github.com/MakoTano/logmon-go	1.683s
```

this PR
```bash
$ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/MakoTano/logmon-go
Benchmark_parseConf-4   	  500000	      2888 ns/op	     192 B/op	       5 allocs/op
PASS
ok  	github.com/MakoTano/logmon-go	1.482s
```

thank you for nice OSS, I've using this in our production. I love it.